### PR TITLE
Remove Cloudflare Integration

### DIFF
--- a/pages/posts/quotes.md
+++ b/pages/posts/quotes.md
@@ -16,3 +16,7 @@ Lines that stuck out to me while reading, provided without context nor explanati
 > "...There are only two or three human stories, and they go on repeating themselves as fiercely as if they had never happened before; like the larks in this country, that have been singing the same five notes over for thousands of years.”
 >
 > Carl Linstrum (**O Pioneers**, Willa Cather)
+
+> "When Fortuna spins you downward, go out to a movie and get more out of life."
+>
+> Ignatius J. Reilly (**A Confederacy of Dunces**, John Kennedy Toole)


### PR DESCRIPTION
This PR removes the integration that was used beforehand for deployments to Cloudflare Pages; namely, because it had little support for the features nested within Next.js. Deployments went well but the site yielded from it, semi-dynamic and almost wholly static, was unusable. Switching to Vercel!